### PR TITLE
start firecracker vm with an ip address

### DIFF
--- a/ansible/roles/setup_host/tasks/setup_firecracker.yml
+++ b/ansible/roles/setup_host/tasks/setup_firecracker.yml
@@ -10,13 +10,19 @@
 
 - name: download firecracker kernel
   get_url:
-    url: https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin
-    dest: ./hello-vmlinux.bin
+    url: https://github.com/firecracker-microvm/firecracker-demo/blob/master/vmlinux?raw=true
+    dest: ./vmlinux
 
 - name: download firecracker fs
   get_url:
-    url: https://s3.amazonaws.com/spec.ccfc.min/img/hello/fsfiles/hello-rootfs.ext4
-    dest: ./hello-rootfs.ext4
+    url: https://github.com/firecracker-microvm/firecracker-demo/blob/master/xenial.rootfs.ext4?raw=true
+    dest: ./xenial.rootfs.ext4
+
+- name: download xenial private key
+  get_url:
+    url: https://github.com/firecracker-microvm/firecracker-demo/blob/master/xenial.rootfs.id_rsa?raw=true
+    dest: ./fc.id_rsa
+    mode: 0400
 
 - import_tasks: install_go.yml
 - import_tasks: build_firectl.yml

--- a/ansible/roles/start_vm/files/start_fc.sh
+++ b/ansible/roles/start_vm/files/start_fc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+sudo modprobe kvm_intel
+
+sudo sysctl -w net.ipv4.conf.all.forwarding=1
+
+SB_ID="0"
+TAP_DEV="fc-${SB_ID}-tap0"
+
+# Setup TAP device that uses proxy ARP
+CIDR="/30"
+NETMASK=255.255.255.252
+FC_IP="$(printf '169.254.%s.%s' $(((4 * SB_ID + 1) / 256)) $(((4 * SB_ID + 1) % 256)))"
+TAP_IP="$(printf '169.254.%s.%s' $(((4 * SB_ID + 2) / 256)) $(((4 * SB_ID + 2) % 256)))"
+FC_MAC="$(printf '02:FC:00:00:%02X:%02X' $((SB_ID / 256)) $((SB_ID % 256)))"
+sudo ip link del "$TAP_DEV" 2> /dev/null || true
+sudo ip tuntap add dev "$TAP_DEV" mode tap
+sudo sysctl -w net.ipv4.conf.${TAP_DEV}.proxy_arp=1 > /dev/null
+sudo sysctl -w net.ipv6.conf.${TAP_DEV}.disable_ipv6=1 > /dev/null
+sudo ip addr add "${TAP_IP}${CIDR}" dev "${TAP_DEV}"
+sudo ip link set dev "$TAP_DEV" up
+
+./firectl --kernel=./vmlinux  --root-drive=./xenial.rootfs.ext4 --kernel-opts="console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw ip=${FC_IP}::${TAP_IP}:${NETMASK}::eth0:off" --tap-device="${TAP_DEV}/${FC_MAC}" --firecracker-binary=./firecracker -m=128

--- a/ansible/roles/start_vm/tasks/execute.yml
+++ b/ansible/roles/start_vm/tasks/execute.yml
@@ -1,15 +1,21 @@
-- debug:
-    msg: "{{ user }}"
-
 - name: set kvm permissions
+  file:
+    path: /dev/kvm
+    mode: 0777
   become: yes
-  shell: "setfacl -m u:{{ user }}:rw /dev/kvm"
+
+- name: check if start_fc.sh exists
+  stat:
+    path: ./start_fc.sh
+  register: start_fc
+
+- name: copy start_fc.sh to host
+  copy:
+    src: ../files/start_fc.sh
+    dest: start_fc.sh
+    owner: "{{ user }}"
+    mode: u=rwx
+  when: not start_fc.stat.exists
 
 - name: start vm
-  shell: >
-         ./firectl \
-          --firecracker-binary=./firecracker \
-          --kernel=./hello-vmlinux.bin \
-          --root-drive=./hello-rootfs.ext4 \
-          --kernel-opts="console=ttyS0 noapic reboot=k panic=1 pci=off nomodules rw" &
-
+  shell: ./start_fc.sh &


### PR DESCRIPTION
The VM will now start with the IP 169.254.0.1, accessible via a tap device
To access:
```
 $ ssh root@169.254.0.1 -i fc.id_rsa
```

TODO:
- allow to pass addresses instead of hard-coding
- use our own custom FS image
- make VM accessible from outside the host