### PR TITLE
clone context and add value when installing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -308,6 +308,7 @@ go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.0.4 h1:bHxbjH6iwh1uInchXadI6hQR107KEbgYsMzoblDONmQ=
 go.mongodb.org/mongo-driver v1.0.4/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
+go.mongodb.org/mongo-driver v1.1.0 h1:aeOqSrhl9eDRAap/3T5pCfMBEBxZ0vuXBP+RMtp2KX8=
 go.mongodb.org/mongo-driver v1.1.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/pkg/api/host.go
+++ b/pkg/api/host.go
@@ -80,7 +80,12 @@ func addHostEndpoint(svc services.Hosts) endpoint.Endpoint {
 					"requestID": ctx.Value(middleware.RequestIDKey),
 					"host":      req.Name,
 				}).Info("Installing host")
-			go svc.InstallHost(ctx, &h, req.LocalNodePath)
+			go svc.InstallHost(
+				context.WithValue(ctx,
+					middleware.RequestIDKey,
+					ctx.Value(middleware.RequestIDKey)),
+				&h,
+				req.LocalNodePath)
 		}
 
 		return IDResponse{ID: id}, err


### PR DESCRIPTION
spawning a goroutine will cause the request to finish
before the goroutine, and we want to keep the context
rather than creating a new one