### PR TITLE
fix StopVM

### DIFF
--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -23,7 +23,7 @@ func NewGRPCConnection() *GRPCConnection {
 	return &GRPCConnection{}
 }
 
-// Connect connects to and `address` and stores it in the internal map
+// Connect connects to an `address` and stores it in the internal map
 func (g *GRPCConnection) Connect(ctx context.Context, address string) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
GetConnection received a wrong key, the connection map uses address:port
as key, and only address was passed